### PR TITLE
feat(nvim): Remove redundant J/K line movement mappings

### DIFF
--- a/neovim/.config/nvim/plugin/20_keymaps.lua
+++ b/neovim/.config/nvim/plugin/20_keymaps.lua
@@ -21,10 +21,6 @@ end
 -- Paste in Visual with `P` to not copy selected text (`:h v_P`)
 -- map('x', 'gp', '"+P', { desc = 'Paste from system clipboard' })
 
--- Moves lines
-map("v", "J", ":m '>+1<CR>gv=gv")
-map("v", "K", ":m '<-2<CR>gv=gv")
-
 -- Navigate wrapped lines
 nmap("j", "gj", "Down (wrapped)")
 nmap("k", "gk", "Up (wrapped)")


### PR DESCRIPTION
mini.move already provides line movement functionality, making these
custom visual mode mappings redundant.