### PR TITLE
feat(nvim): Remove treesitter text objects dependency

### DIFF
--- a/neovim/.config/nvim/plugin/30_mini.lua
+++ b/neovim/.config/nvim/plugin/30_mini.lua
@@ -106,14 +106,9 @@ later(function()
         custom_textobjects = {
             B = gen_ai_spec.buffer(),
             D = gen_ai_spec.diagnostic(),
-            F = ai.gen_spec.treesitter({ a = '@function.outer', i = '@function.inner' }),
             I = gen_ai_spec.indent(),
             L = gen_ai_spec.line(),
             N = gen_ai_spec.number(),
-            o = ai.gen_spec.treesitter({
-                a = { '@conditional.outer', '@loop.outer' },
-                i = { '@conditional.inner', '@loop.inner' },
-            }),
         },
     })
 end)

--- a/neovim/.config/nvim/plugin/40_plugins.lua
+++ b/neovim/.config/nvim/plugin/40_plugins.lua
@@ -20,10 +20,6 @@ now_if_args(function()
         -- Perform action after every checkout
         hooks = { post_checkout = function() vim.cmd('TSUpdate') end },
     })
-    add({
-        source = 'nvim-treesitter/nvim-treesitter-textobjects',
-        checkout = 'main',
-    })
 
     -- Ensure installed
     local languages = {


### PR DESCRIPTION
Remove nvim-treesitter-textobjects plugin and mini.ai treesitter-based
text objects (F and o). Simplifies configuration by eliminating
dependency on treesitter for text object functionality.