### PR TITLE
feat(nvim): Add mini.input setup in later block

### DIFF
--- a/neovim/.config/nvim/plugin/30_mini.lua
+++ b/neovim/.config/nvim/plugin/30_mini.lua
@@ -282,6 +282,13 @@ end)
 
 later(function() require('mini.indentscope').setup() end)
 
+-- Customizable user input with floating window, statusline, or virtual text views.
+-- Overrides vim.ui.input() with a richer, non-blocking implementation.
+later(function()
+    require('mini.input').setup()
+    vim.ui.input = MiniInput.ui_input
+end)
+
 -- Special key mappings. Provides helpers to map:
 -- - Multi-step actions. Apply action 1 if condition is met; else apply
 --   action 2 if condition is met; etc.

--- a/neovim/.config/nvim/plugin/30_mini.lua
+++ b/neovim/.config/nvim/plugin/30_mini.lua
@@ -284,10 +284,7 @@ later(function() require('mini.indentscope').setup() end)
 
 -- Customizable user input with floating window, statusline, or virtual text views.
 -- Overrides vim.ui.input() with a richer, non-blocking implementation.
-later(function()
-    require('mini.input').setup()
-    vim.ui.input = MiniInput.ui_input
-end)
+later(function() require('mini.input').setup() end)
 
 -- Special key mappings. Provides helpers to map:
 -- - Multi-step actions. Apply action 1 if condition is met; else apply


### PR DESCRIPTION
Adds mini.input to override vim.ui.input() with a customizable floating
window implementation, consistent with mini.pick overriding vim.ui.select.

https://claude.ai/code/session_01FbAW5ufGpxv8PHKJU8Wx9n