### PR TITLE
feat(nvim): close remaining gaps from MiniMax nvim-0.12 reference

### DIFF
--- a/neovim/.config/nvim/plugin/10_options.lua
+++ b/neovim/.config/nvim/plugin/10_options.lua
@@ -35,6 +35,7 @@ vim.o.showmode        = false              -- Don't show mode in command line
 vim.o.sidescrolloff   = 8                  -- line scroll context
 vim.o.signcolumn      = 'yes'              -- Always show sign column (otherwise it will shift text)
 vim.o.splitbelow      = true               -- Horizontal splits will be below
+vim.o.splitkeep       = 'screen'           -- Reduce scroll during window split
 vim.o.splitright      = true               -- Vertical splits will be to the right
 vim.o.winborder       = 'single'           -- Use border in floating windows
 vim.o.wrap            = false              -- Display long lines as just one line

--- a/neovim/.config/nvim/plugin/20_keymaps.lua
+++ b/neovim/.config/nvim/plugin/20_keymaps.lua
@@ -87,6 +87,9 @@ local explore_quickfix = function()
     end
     vim.cmd('copen')
 end
+local explore_locations = function()
+    vim.cmd(vim.fn.getloclist(0, { winid = true }).winid ~= 0 and 'lclose' or 'lopen')
+end
 
 nmap_leader('ed', '<Cmd>lua MiniFiles.open()<CR>', 'Directory')
 nmap_leader('ef', explore_at_file, 'File directory')
@@ -97,6 +100,7 @@ nmap_leader('en', '<Cmd>lua MiniNotify.show_history()<CR>', 'Notifications')
 nmap_leader('eo', edit_plugin_file('10_options.lua'), 'Options config')
 nmap_leader('ep', edit_plugin_file('40_plugins.lua'), 'Plugins config')
 nmap_leader('eq', explore_quickfix, 'Quickfix')
+nmap_leader('eQ', explore_locations, 'Location list')
 nmap_leader('es', '<Cmd>lua MiniSessions.select()<CR>', 'Sessions')
 
 -- f is for 'Fuzzy Find'. Common usage:
@@ -226,11 +230,12 @@ nmap_leader('oz', '<Cmd>lua MiniMisc.zoom()<CR>', 'Zoom toggle')
 -- - `<Leader>sn` - start new session
 -- - `<Leader>sr` - read previously started session
 -- - `<Leader>sd` - delete previously started session
-local session_new = 'MiniSessions.write(vim.fn.input("Session name: "))'
+local session_new = 'vim.ui.input({ prompt = "Session name: " }, MiniSessions.write)'
 
 nmap_leader('sd', '<Cmd>lua MiniSessions.select("delete")<CR>', 'Delete')
 nmap_leader('sn', '<Cmd>lua ' .. session_new .. '<CR>', 'New')
 nmap_leader('sr', '<Cmd>lua MiniSessions.select("read")<CR>', 'Read')
+nmap_leader('sR', '<Cmd>lua MiniSessions.restart()<CR>', 'Restart')
 nmap_leader('sw', '<Cmd>lua MiniSessions.write()<CR>', 'Write current')
 
 -- t is for 'Terminal'

--- a/neovim/.config/nvim/plugin/30_mini.lua
+++ b/neovim/.config/nvim/plugin/30_mini.lua
@@ -385,6 +385,15 @@ end)
 --     vim.keymap.set({ 'i', 's' }, '<C-h>', jump_prev)
 -- end)
 
+-- Split and join arguments (regions inside brackets between allowed separators).
+-- Example usage:
+-- - `gS` - toggle between joined (all in one line) and split (each on a separate
+--   line and indented) arguments. It is dot-repeatable (see `:h .`).
+--
+-- See also:
+-- - `:h MiniSplitjoin.gen_hook` - list of available hooks
+later(function() require('mini.splitjoin').setup() end)
+
 later(function() require('mini.surround').setup() end)
 
 later(function() require('mini.trailspace').setup() end)

--- a/neovim/.config/nvim/plugin/40_plugins.lua
+++ b/neovim/.config/nvim/plugin/40_plugins.lua
@@ -83,7 +83,7 @@ later(function()
         'marksman',
         'pyright',
         'rust_analyzer',
-        'sourcekit', -- not installed through Mason
+        'sourcekit',
         'terraformls',
         'tsgo',
     })

--- a/neovim/.config/nvim/plugin/40_plugins.lua
+++ b/neovim/.config/nvim/plugin/40_plugins.lua
@@ -70,24 +70,23 @@ end)
 later(function()
     add({
         'https://github.com/neovim/nvim-lspconfig',
+        -- Used only as an installer for the servers below (`:Mason` to manage).
+        -- Enabling is done explicitly via `vim.lsp.enable()`, not mason-lspconfig.
         'https://github.com/mason-org/mason.nvim',
-        'https://github.com/mason-org/mason-lspconfig.nvim',
     })
     require('mason').setup()
-    require("mason-lspconfig").setup {
-        ensure_installed = {
-            "harper_ls",
-            "lua_ls",
-            "marksman",
-            "pyright",
-            "rust_analyzer",
-            "terraformls",
-            "tsgo",
-        },
-    }
 
-    -- not included in mason lsp config
-    vim.lsp.enable('sourcekit')
+    -- Configure via 'nvim-lspconfig' defaults or 'after/lsp/' overrides.
+    vim.lsp.enable({
+        'harper_ls',
+        'lua_ls',
+        'marksman',
+        'pyright',
+        'rust_analyzer',
+        'sourcekit', -- not installed through Mason
+        'terraformls',
+        'tsgo',
+    })
 end)
 
 -- Completion =================================================================


### PR DESCRIPTION
- Enable mini.splitjoin for gS argument split/join
- Set splitkeep=screen to reduce scroll jank on window split
- Add <Leader>eQ to toggle the location list
- Add <Leader>sR to restart Neovim with the current session
- Use vim.ui.input() for the session-name prompt so mini.input renders it
- Drop mason-lspconfig in favor of explicit vim.lsp.enable(); mason.nvim
  stays only as the installer/PATH provider for Mason-managed servers